### PR TITLE
DEV: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Describe the bug
+A clear and concise description of what the bug is.
+
+# To Reproduce
+Steps to reproduce the behavior:
+1. Download data from '...'
+2. Load data into Python '....'
+3. Call function '....'
+4. See error
+
+# Expected behavior
+A clear and concise description of what you expected to happen.
+
+# Error message
+Copy-pasting the complete error message is usually more useful
+
+# Computer information (please complete the following information):
+ - OS: [e.g. iOS]
+ - Python version: [e.g. 3.7.11]
+ - Package version: [e.g. 1.0.0]
+
+# Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add issue templates for the more common problems.  GitHub should still allow a blank issue if these don't fit.